### PR TITLE
Make CML 2.8 work a on AWS and Azure

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019-2024 Cisco
+   Copyright 2019-2025 Cisco
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -118,17 +118,21 @@ Regardless of the secret manager in use or whether you use random passwords or n
 ##### CyberArk Conjur installation
 
 > [!IMPORTANT]
-> CyberArk Conjur is not currently in the Terraform Registry.  You must follow its [installation instructions](https://github.com/cyberark/terraform-provider-conjur?tab=readme-ov-file#terraform-provider-conjur) before running `terraform init`. 
+> CyberArk Conjur is not currently in the Terraform Registry.  You must follow its [installation instructions](https://github.com/cyberark/terraform-provider-conjur?tab=readme-ov-file#terraform-provider-conjur) before running `terraform init`.
 
 These steps are only required if using CyberArk Conjur as an external secrets manager.
+
 1. Download the [CyberArk Conjur provider](https://github.com/cyberark/terraform-provider-conjur/releases).
 2. Copy the custom provider to `~/.terraform.d/plugins/localhost/cyberark/conjur/<version>/<architecture>/terraform-provider-conjur_v<version>`
+
    ```bash
    $ mkdir -vp ~/.terraform.d/plugins/localhost/cyberark/conjur/0.6.7/darwin_arm64/
    $ unzip ~/terraform-provider-conjur_0.6.7-4_darwin_arm64.zip -d ~/.terraform.d/plugins/localhost/cyberark/conjur/0.6.7/darwin_arm64/
    $
    ```
+
 3. Create a `.terraformrc` file in the user's home:
+
    ```hcl
    provider_installation {
      filesystem_mirror {
@@ -180,11 +184,11 @@ There's two Terraform variables which can be defined / set to further customize 
 - `cfg_extra_vars`: This variable defines the name of a file with additional variable definitions.  The default is "none".
 
 ```bash
-export TF_VAR_access_key="aws-something"
-export TF_VAR_secret_key="aws-somethingelse"
+export TF_VAR_aws_access_key="aws-something"
+export TF_VAR_aws_secret_key="aws-somethingelse"
 
-# export TF_VAR_subscription_id="azure-something"
-# export TF_VAR_tenant_id="azure-something-else"
+# export TF_VAR_azure_subscription_id="azure-something"
+# export TF_VAR_azure_tenant_id="azure-something-else"
 
 export TF_VAR_cfg_file="config-custom.yml"
 export TF_VAR_cfg_extra_vars="extras.sh"

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/config.yml
+++ b/config.yml
@@ -27,6 +27,7 @@ aws:
   # When specifying a VPC ID below then this prefix must exist on that VPC!
   public_vpc_ipv4_cidr: 10.0.0.0/16
   enable_ebs_encryption: false
+  allowed_ipv4_subnets: ["0.0.0.0/0"]
   #
   # Leave empty to create a custom VPC / Internet gateway, or provide the IDs
   # of the VPC / gateway to use, they must exist and properly associated.
@@ -45,12 +46,12 @@ azure:
   size_compute: unused_at_the_moment
   storage_account: storage-account-name
   container_name: container-name
+  allowed_ipv4_subnets: ["*"]
 
 common:
   disk_size: 64
   controller_hostname: cml-controller
   key_name: ssh-key-name
-  allowed_ipv4_subnets: ["0.0.0.0/0"]
   enable_patty: true
 
 cluster:

--- a/config.yml
+++ b/config.yml
@@ -27,7 +27,6 @@ aws:
   # When specifying a VPC ID below then this prefix must exist on that VPC!
   public_vpc_ipv4_cidr: 10.0.0.0/16
   enable_ebs_encryption: false
-  allowed_ipv4_subnets: ["0.0.0.0/0"]
   #
   # Leave empty to create a custom VPC / Internet gateway, or provide the IDs
   # of the VPC / gateway to use, they must exist and properly associated.
@@ -46,12 +45,12 @@ azure:
   size_compute: unused_at_the_moment
   storage_account: storage-account-name
   container_name: container-name
-  allowed_ipv4_subnets: ["*"]
 
 common:
   disk_size: 64
   controller_hostname: cml-controller
   key_name: ssh-key-name
+  allowed_ipv4_subnets: ["0.0.0.0/0"]
   enable_patty: true
 
 cluster:

--- a/documentation/AWS.md
+++ b/documentation/AWS.md
@@ -44,7 +44,7 @@ As mentioned at the top, there's an `aws-mini` deployment option as an alternati
 
 The mini flavor is useful in case the AWS networking infrastructure is already in place and can not or should not be modified, cloud-cml should simply create a CML instance that uses the existing networking infrastructure by providing the subnet ID and the security group ID that should be used to attach the CML VM to.
 
-*If no Elastic IP should be used and the server should use a private IP from the configured subnet instead then this is configurable in the .tf file.  See the comment for the `resource "aws_eip" "server_eip"` inside of `main.tf` for the mini variant. 
+*If no Elastic IP should be used and the server should use a private IP from the configured subnet instead then this is configurable in the .tf file.  See the comment for the `resource "aws_eip" "server_eip"` inside of `main.tf` for the mini variant.
 
 #### How to enable the mini variant
 
@@ -303,7 +303,7 @@ The final step is about creating access credentials that can be used with Terraf
 - click on "Create access key"
 - make a note of the access key and the secret key (copy them into an editor so that they can be later used when editing the `config.yml` of the deployment tool)
 
-This access key and the associated secret key must be provided to the AWS Terraform provider via the the variables `access_key` and `secret_key`, ideally via environment variables or a vault. See the Variables section below.
+This access key and the associated secret key must be provided to the AWS Terraform provider via the variables `aws_access_key` and `aws_secret_key`, ideally via environment variables or a vault. See the Variables section below.
 
 #### Example
 
@@ -533,8 +533,8 @@ Here's an example using a bash script that can be sourced and which defines thos
 Content of file `.envrc`:
 
 ```bash
-export TF_VAR_access_key="your-access-key-string-from-iam"
-export TF_VAR_secret_key="your-secret-key-string-from-iam"
+export TF_VAR_aws_access_key="your-access-key-string-from-iam"
+export TF_VAR_aws_secret_key="your-secret-key-string-from-iam"
 ```
 
 Alternatively, it's also possible to provide values for variables via a file called `terraform.tfvars` file. There are various ways how to define / set variables with Terraform. See the Terraform [documentation](https://developer.hashicorp.com/terraform/language/values/variables#assigning-values-to-root-module-variables) for additional details.

--- a/documentation/AWS.md
+++ b/documentation/AWS.md
@@ -367,7 +367,7 @@ AWS CLI configurations are stored in `$HOME/.aws`.
 
 If everything was configured correct then you should be able to list instances (remember that we permitted EC2 access for the deployment users):
 
-```
+```bash
 $ aws ec2 describe-instances
 {
     "Reservations": []
@@ -379,7 +379,7 @@ As there are no instances running in this case, the output is empty. The importa
 
 ### Configuration file
 
-CML specific settings are specified in the configuration file `config.yml`.  See also [VPC support](#vpc-support) and [Cluster support](#cluster-suport) sections further down in the document.
+CML specific settings are specified in the configuration file `config.yml`.  See also [VPC support](#vpc-support) and [Cluster support](#cluster-support) sections further down in the document.
 
 #### AWS section
 
@@ -515,7 +515,7 @@ Start the tool by providing the bucket name as an argument and the location of t
 
 The tool will then display a simple dialog where the images which should be copied to the bucket can be selected:
 
-![](../images/upload-refplat.png)
+![Dialog preview](../images/upload-refplat.png)
 
 After selecting OK the upload process will be started immediately. To abort the process, Ctrl-C can be used.
 
@@ -538,6 +538,8 @@ export TF_VAR_secret_key="your-secret-key-string-from-iam"
 ```
 
 Alternatively, it's also possible to provide values for variables via a file called `terraform.tfvars` file. There are various ways how to define / set variables with Terraform. See the Terraform [documentation](https://developer.hashicorp.com/terraform/language/values/variables#assigning-values-to-root-module-variables) for additional details.
+
+In addition to the above methods, Terraform can also automatically retrieve authentication credentials from the AWS configuration files located in the .aws folder. This includes credentials set up by running `aws configure`, which stores your access key and secret key in the `~/.aws/credentials` file. This method allows Terraform to use the same credentials configured for the AWS CLI, [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs).
 
 ## Lifecycle management
 

--- a/documentation/Azure.md
+++ b/documentation/Azure.md
@@ -45,8 +45,8 @@ The provided subscription ID and the tenant ID need to be configured as Terrafor
 
 { read subID ; read tenantID; } <<< "$(az account list --output=json | jq -r '.[0]|.id,.tenantId')"
 
-export TF_VAR_tenant_id="$tenantID"
-export TF_VAR_subscription_id="$subID"
+export TF_VAR_azure_tenant_id="$tenantID"
+export TF_VAR_azure_subscription_id="$subID"
 ```
 
 The values can be provided directly as well (e.g. copying and pasting them into the script).

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,8 @@ module "deploy" {
   source = "./modules/deploy"
   cfg    = local.cfg
   extras = local.extras
+  azure_subscription_id = var.subscription_id
+  azure_tenant_id       = var.tenant_id
 }
 
 provider "cml2" {

--- a/main.tf
+++ b/main.tf
@@ -25,11 +25,11 @@ module "secrets" {
 }
 
 module "deploy" {
-  source = "./modules/deploy"
-  cfg    = local.cfg
-  extras = local.extras
-  azure_subscription_id = var.subscription_id
-  azure_tenant_id       = var.tenant_id
+  source                = "./modules/deploy"
+  cfg                   = local.cfg
+  extras                = local.extras
+  azure_subscription_id = var.azure_subscription_id
+  azure_tenant_id       = var.azure_tenant_id
 }
 
 provider "cml2" {

--- a/modules/deploy/aws-mini/main.tf
+++ b/modules/deploy/aws-mini/main.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/aws-mini/main.tf
+++ b/modules/deploy/aws-mini/main.tf
@@ -40,6 +40,7 @@ locals {
     copyfile      = var.options.copyfile
     del           = var.options.del
     interface_fix = var.options.interface_fix
+    license       = var.options.license
     extras        = var.options.extras
     hostname      = var.options.cfg.common.controller_hostname
     path          = path.module
@@ -93,7 +94,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-noble-24.04-amd64-server-*"]
   }
 
   filter {

--- a/modules/deploy/aws-mini/output.tf
+++ b/modules/deploy/aws-mini/output.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/aws-mini/variables.tf
+++ b/modules/deploy/aws-mini/variables.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/aws-off.t-f
+++ b/modules/deploy/aws-off.t-f
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/aws-on.t-f
+++ b/modules/deploy/aws-on.t-f
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/aws/main.tf
+++ b/modules/deploy/aws/main.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/aws/main.tf
+++ b/modules/deploy/aws/main.tf
@@ -87,7 +87,7 @@ locals {
       "from_port" : 1122,
       "to_port" : 1122
       "protocol" : "tcp",
-      "cidr_blocks" : var.options.cfg.aws.allowed_ipv4_subnets,
+      "cidr_blocks" : var.options.cfg.common.allowed_ipv4_subnets,
       "ipv6_cidr_blocks" : [],
       "prefix_list_ids" : [],
       "security_groups" : [],
@@ -98,7 +98,7 @@ locals {
       "from_port" : 22,
       "to_port" : 22
       "protocol" : "tcp",
-      "cidr_blocks" : var.options.cfg.aws.allowed_ipv4_subnets,
+      "cidr_blocks" : var.options.cfg.common.allowed_ipv4_subnets,
       "ipv6_cidr_blocks" : [],
       "prefix_list_ids" : [],
       "security_groups" : [],
@@ -109,7 +109,7 @@ locals {
       "from_port" : 9090,
       "to_port" : 9090
       "protocol" : "tcp",
-      "cidr_blocks" : var.options.cfg.aws.allowed_ipv4_subnets,
+      "cidr_blocks" : var.options.cfg.common.allowed_ipv4_subnets,
       "ipv6_cidr_blocks" : [],
       "prefix_list_ids" : [],
       "security_groups" : [],
@@ -120,7 +120,7 @@ locals {
       "from_port" : 80,
       "to_port" : 80
       "protocol" : "tcp",
-      "cidr_blocks" : var.options.cfg.aws.allowed_ipv4_subnets,
+      "cidr_blocks" : var.options.cfg.common.allowed_ipv4_subnets,
       "ipv6_cidr_blocks" : [],
       "prefix_list_ids" : [],
       "security_groups" : [],
@@ -131,7 +131,7 @@ locals {
       "from_port" : 443,
       "to_port" : 443
       "protocol" : "tcp",
-      "cidr_blocks" : var.options.cfg.aws.allowed_ipv4_subnets,
+      "cidr_blocks" : var.options.cfg.common.allowed_ipv4_subnets,
       "ipv6_cidr_blocks" : [],
       "prefix_list_ids" : [],
       "security_groups" : [],
@@ -145,7 +145,7 @@ locals {
       "from_port" : 2000,
       "to_port" : 7999
       "protocol" : "tcp",
-      "cidr_blocks" : var.options.cfg.aws.allowed_ipv4_subnets,
+      "cidr_blocks" : var.options.cfg.common.allowed_ipv4_subnets,
       "ipv6_cidr_blocks" : [],
       "prefix_list_ids" : [],
       "security_groups" : [],
@@ -156,7 +156,7 @@ locals {
       "from_port" : 2000,
       "to_port" : 7999
       "protocol" : "udp",
-      "cidr_blocks" : var.options.cfg.aws.allowed_ipv4_subnets,
+      "cidr_blocks" : var.options.cfg.common.allowed_ipv4_subnets,
       "ipv6_cidr_blocks" : [],
       "prefix_list_ids" : [],
       "security_groups" : [],

--- a/modules/deploy/aws/main.tf
+++ b/modules/deploy/aws/main.tf
@@ -87,7 +87,7 @@ locals {
       "from_port" : 1122,
       "to_port" : 1122
       "protocol" : "tcp",
-      "cidr_blocks" : var.options.cfg.common.allowed_ipv4_subnets,
+      "cidr_blocks" : var.options.cfg.aws.allowed_ipv4_subnets,
       "ipv6_cidr_blocks" : [],
       "prefix_list_ids" : [],
       "security_groups" : [],
@@ -98,7 +98,7 @@ locals {
       "from_port" : 22,
       "to_port" : 22
       "protocol" : "tcp",
-      "cidr_blocks" : var.options.cfg.common.allowed_ipv4_subnets,
+      "cidr_blocks" : var.options.cfg.aws.allowed_ipv4_subnets,
       "ipv6_cidr_blocks" : [],
       "prefix_list_ids" : [],
       "security_groups" : [],
@@ -109,7 +109,7 @@ locals {
       "from_port" : 9090,
       "to_port" : 9090
       "protocol" : "tcp",
-      "cidr_blocks" : var.options.cfg.common.allowed_ipv4_subnets,
+      "cidr_blocks" : var.options.cfg.aws.allowed_ipv4_subnets,
       "ipv6_cidr_blocks" : [],
       "prefix_list_ids" : [],
       "security_groups" : [],
@@ -120,7 +120,7 @@ locals {
       "from_port" : 80,
       "to_port" : 80
       "protocol" : "tcp",
-      "cidr_blocks" : var.options.cfg.common.allowed_ipv4_subnets,
+      "cidr_blocks" : var.options.cfg.aws.allowed_ipv4_subnets,
       "ipv6_cidr_blocks" : [],
       "prefix_list_ids" : [],
       "security_groups" : [],
@@ -131,7 +131,7 @@ locals {
       "from_port" : 443,
       "to_port" : 443
       "protocol" : "tcp",
-      "cidr_blocks" : var.options.cfg.common.allowed_ipv4_subnets,
+      "cidr_blocks" : var.options.cfg.aws.allowed_ipv4_subnets,
       "ipv6_cidr_blocks" : [],
       "prefix_list_ids" : [],
       "security_groups" : [],
@@ -145,7 +145,7 @@ locals {
       "from_port" : 2000,
       "to_port" : 7999
       "protocol" : "tcp",
-      "cidr_blocks" : var.options.cfg.common.allowed_ipv4_subnets,
+      "cidr_blocks" : var.options.cfg.aws.allowed_ipv4_subnets,
       "ipv6_cidr_blocks" : [],
       "prefix_list_ids" : [],
       "security_groups" : [],
@@ -156,7 +156,7 @@ locals {
       "from_port" : 2000,
       "to_port" : 7999
       "protocol" : "udp",
-      "cidr_blocks" : var.options.cfg.common.allowed_ipv4_subnets,
+      "cidr_blocks" : var.options.cfg.aws.allowed_ipv4_subnets,
       "ipv6_cidr_blocks" : [],
       "prefix_list_ids" : [],
       "security_groups" : [],
@@ -279,6 +279,7 @@ resource "aws_network_interface" "pub_int_cml" {
 resource "aws_eip" "server_eip" {
   network_interface = aws_network_interface.pub_int_cml.id
   tags              = { "Name" = "CML-controller-eip-${var.options.rand_id}", "device" = "server" }
+  depends_on = [aws_instance.cml_controller]
 }
 
 #------------- compute subnet, NAT GW, routing and interfaces -----------------
@@ -498,7 +499,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
   }
 
   filter {

--- a/modules/deploy/aws/main.tf
+++ b/modules/deploy/aws/main.tf
@@ -59,6 +59,7 @@ locals {
     copyfile      = var.options.copyfile
     del           = var.options.del
     interface_fix = var.options.interface_fix
+    license       = var.options.license
     extras        = var.options.extras
     hostname      = var.options.cfg.common.controller_hostname
     path          = path.module
@@ -73,6 +74,7 @@ locals {
     copyfile      = var.options.copyfile
     del           = var.options.del
     interface_fix = var.options.interface_fix
+    license       = "empty"
     extras        = var.options.extras
     hostname      = local.compute_hostnames[i]
     path          = path.module
@@ -279,7 +281,7 @@ resource "aws_network_interface" "pub_int_cml" {
 resource "aws_eip" "server_eip" {
   network_interface = aws_network_interface.pub_int_cml.id
   tags              = { "Name" = "CML-controller-eip-${var.options.rand_id}", "device" = "server" }
-  depends_on = [aws_instance.cml_controller]
+  depends_on        = [aws_instance.cml_controller]
 }
 
 #------------- compute subnet, NAT GW, routing and interfaces -----------------

--- a/modules/deploy/aws/output.tf
+++ b/modules/deploy/aws/output.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/aws/output.tf
+++ b/modules/deploy/aws/output.tf
@@ -5,7 +5,7 @@
 #
 
 output "public_ip" {
-  value = aws_instance.cml_controller.public_ip
+  value = aws_eip.server_eip.public_ip
 }
 
 output "sas_token" {

--- a/modules/deploy/aws/variables.tf
+++ b/modules/deploy/aws/variables.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/azure-off.t-f
+++ b/modules/deploy/azure-off.t-f
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/azure-on.t-f
+++ b/modules/deploy/azure-on.t-f
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/azure/main.tf
+++ b/modules/deploy/azure/main.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/azure/main.tf
+++ b/modules/deploy/azure/main.tf
@@ -105,7 +105,7 @@ resource "azurerm_network_security_rule" "cml_std" {
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_ranges     = [22, 80, 443, 1122, 9090]
-  source_address_prefixes     = var.options.cfg.azure.allowed_ipv4_subnets
+  source_address_prefixes     = var.options.cfg.common.allowed_ipv4_subnets
   destination_address_prefix  = "*"
   resource_group_name         = data.azurerm_resource_group.cml.name
   network_security_group_name = azurerm_network_security_group.cml.name
@@ -120,7 +120,7 @@ resource "azurerm_network_security_rule" "cml_patty_tcp" {
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "2000-7999"
-  source_address_prefixes     = var.options.cfg.azure.allowed_ipv4_subnets
+  source_address_prefixes     = var.options.cfg.common.allowed_ipv4_subnets
   destination_address_prefix  = "*"
   resource_group_name         = data.azurerm_resource_group.cml.name
   network_security_group_name = azurerm_network_security_group.cml.name
@@ -135,7 +135,7 @@ resource "azurerm_network_security_rule" "cml_patty_udp" {
   protocol                    = "Udp"
   source_port_range           = "*"
   destination_port_range      = "2000-7999"
-  source_address_prefixes     = var.options.cfg.azure.allowed_ipv4_subnets
+  source_address_prefixes     = var.options.cfg.common.allowed_ipv4_subnets
   destination_address_prefix  = "*"
   resource_group_name         = data.azurerm_resource_group.cml.name
   network_security_group_name = azurerm_network_security_group.cml.name

--- a/modules/deploy/azure/main.tf
+++ b/modules/deploy/azure/main.tf
@@ -105,7 +105,7 @@ resource "azurerm_network_security_rule" "cml_std" {
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_ranges     = [22, 80, 443, 1122, 9090]
-  source_address_prefix       = "*"
+  source_address_prefixes     = var.options.cfg.azure.allowed_ipv4_subnets
   destination_address_prefix  = "*"
   resource_group_name         = data.azurerm_resource_group.cml.name
   network_security_group_name = azurerm_network_security_group.cml.name
@@ -120,7 +120,7 @@ resource "azurerm_network_security_rule" "cml_patty_tcp" {
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "2000-7999"
-  source_address_prefix       = "*"
+  source_address_prefixes     = var.options.cfg.azure.allowed_ipv4_subnets
   destination_address_prefix  = "*"
   resource_group_name         = data.azurerm_resource_group.cml.name
   network_security_group_name = azurerm_network_security_group.cml.name
@@ -135,7 +135,7 @@ resource "azurerm_network_security_rule" "cml_patty_udp" {
   protocol                    = "Udp"
   source_port_range           = "*"
   destination_port_range      = "2000-7999"
-  source_address_prefix       = "*"
+  source_address_prefixes     = var.options.cfg.azure.allowed_ipv4_subnets
   destination_address_prefix  = "*"
   resource_group_name         = data.azurerm_resource_group.cml.name
   network_security_group_name = azurerm_network_security_group.cml.name
@@ -235,8 +235,8 @@ resource "azurerm_linux_virtual_machine" "cml" {
   # https://canonical-azure.readthedocs-hosted.com/en/latest/azure-explanation/daily-vs-release-images/
   source_image_reference {
     publisher = "Canonical"
-    offer     = "0001-com-ubuntu-server-focal"
-    sku       = "20_04-lts"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server"
     version   = "latest"
   }
 

--- a/modules/deploy/azure/main.tf
+++ b/modules/deploy/azure/main.tf
@@ -37,6 +37,7 @@ locals {
     copyfile      = var.options.copyfile
     del           = var.options.del
     interface_fix = var.options.interface_fix
+    license       = var.options.license
     extras        = var.options.extras
     hostname      = var.options.cfg.common.controller_hostname
     path          = path.module
@@ -236,7 +237,7 @@ resource "azurerm_linux_virtual_machine" "cml" {
   source_image_reference {
     publisher = "Canonical"
     offer     = "ubuntu-24_04-lts"
-    sku       = "server"
+    sku       = "minimal"
     version   = "latest"
   }
 

--- a/modules/deploy/azure/output.tf
+++ b/modules/deploy/azure/output.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/azure/output.tf
+++ b/modules/deploy/azure/output.tf
@@ -5,7 +5,7 @@
 #
 
 output "public_ip" {
-  value = azurerm_linux_virtual_machine.cml.public_ip_address
+  value = azurerm_public_ip.cml.ip_address
 }
 
 output "sas_token" {

--- a/modules/deploy/azure/variables.tf
+++ b/modules/deploy/azure/variables.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/data/00-patch_vmx.sh
+++ b/modules/deploy/data/00-patch_vmx.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/data/00-patch_vmx.sh
+++ b/modules/deploy/data/00-patch_vmx.sh
@@ -14,7 +14,7 @@
 # Some platforms like Linux, IOSv and IOSv-L2 will still work but others will
 # not and crash!
 
-echo -n "no-VMX patch..."
+echo "no-VMX patch..."
 (
     cd /var/local/virl2/.local/lib/python3.12/site-packages
     patch -p1 --forward <<EOF

--- a/modules/deploy/data/00-patch_vmx.sh
+++ b/modules/deploy/data/00-patch_vmx.sh
@@ -17,7 +17,7 @@
 
 echo -n "no-VMX patch..."
 (
-    cd /var/local/virl2/.local/lib/python3.8/site-packages
+    cd /var/local/virl2/.local/lib/python3.12/site-packages
     patch -p1 --forward <<EOF
 diff -ru a/simple_core/libvirt/templates/qemu_node.xml b/simple_core/libvirt/templates/qemu_node.xml
 --- a/simple_core/libvirt/templates/qemu_node.xml 2023-02-25 22:05:12.000000000 +0000
@@ -36,19 +36,18 @@ diff -ru a/simple_core/libvirt/templates/qemu_node.xml b/simple_core/libvirt/tem
          <type arch="x86_64" machine="pc">hvm</type>
          <boot dev="hd"/>
 diff -ru a/simple_drivers/low_level_driver/host_statistics.py b/simple_drivers/low_level_driver/host_statistics.py
---- a/simple_drivers/low_level_driver/host_statistics.py  2023-02-25 22:05:12.000000000 +0000
-+++ b/simple_drivers/low_level_driver/host_statistics.py  2023-03-07 08:25:58.774945279 +0000
-@@ -267,7 +267,9 @@
- 
- 
-         virtualization = self._get_cpu_info_field("Virtualization")
+--- a/simple_drivers/low_level_driver/host_statistics.py
++++ b/simple_drivers/low_level_driver/host_statistics.py
+@@ -489,7 +489,8 @@ class LLDSystemInfo:
+         # return vmx or svm
+         #
+         virtualization: str | None = self._get_cpu_info_field("Virtualization")
 -        return virtualization in ("VT-x", "AMD-V")
 +        # return virtualization in ("VT-x", "AMD-V")
 +        return True
-+
  
-     def stats(self):
- 
+     def stats(self) -> dict[str, dict[str, Any]]:
+         """This is periodically called every heartbeat from
 EOF
     systemctl restart virl2.target
 )

--- a/modules/deploy/data/03-letsencrypt.sh
+++ b/modules/deploy/data/03-letsencrypt.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/data/03-letsencrypt.sh
+++ b/modules/deploy/data/03-letsencrypt.sh
@@ -73,13 +73,15 @@ if ! [ -d /etc/letsencrypt/live/$CFG_HN ]; then
 fi
 
 # copy the cert to the nginx configuration
-cp /etc/letsencrypt/live/$CFG_HN/fullchain.pem /etc/nginx/fullchain.pem
+mkdir /etc/nginx/oldcerts
+mv /etc/nginx/*.pem /etc/nginx/oldcerts/
+cp /etc/letsencrypt/live/$CFG_HN/fullchain.pem /etc/nginx/pubkey.pem
 cp /etc/letsencrypt/live/$CFG_HN/privkey.pem /etc/nginx/privkey.pem
 
-# write the cert chain into the file that Cockpit uses
-cat /etc/letsencrypt/live/$CFG_HN/privkey.pem \
-    /etc/letsencrypt/live/$CFG_HN/fullchain.pem \
-    >/etc/cockpit/ws-certs.d/0-self-signed.cert
+# write the cert into the file that Cockpit uses, note that Cockpit wants
+# the cert only, not the full chain.
+cat /etc/letsencrypt/live/$CFG_HN/privkey.pem >/etc/cockpit/ws-certs.d/0-self-signed.key
+sed '/-----END CERTIFICATE-----/q' $ /etc/letsencrypt/live/$CFG_HN/fullchain.pem >/etc/cockpit/ws-certs.d/0-self-signed.cert
 
 # reload affected services
 systemctl reload nginx

--- a/modules/deploy/data/04-customize.sh
+++ b/modules/deploy/data/04-customize.sh
@@ -66,7 +66,7 @@ for id in range(0, USER_COUNT + 1):
     client.user_management.create_user(f"pod{id}", f"{id:#02}DevWks{id:#02}", resource_pool=rp.id)
 EOF
 
-sleep 15  # wait for licensing to happen
+sleep 15 # wait for licensing to happen
 export CFG_APP_PASS CFG_COMMON_HOSTNAME
 export HOME=/var/local/virl2
 python3 /provision/users.py

--- a/modules/deploy/data/04-customize.sh
+++ b/modules/deploy/data/04-customize.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+#
+# This file is part of Cisco Modeling Labs
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
+# All rights reserved.
+#
 
 source /provision/common.sh
 source /provision/copyfile.sh

--- a/modules/deploy/data/99-dummy.sh
+++ b/modules/deploy/data/99-dummy.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/data/cloud-config.txt
+++ b/modules/deploy/data/cloud-config.txt
@@ -44,6 +44,11 @@ write_files:
     permissions: "0700"
     content: |
       ${indent(6, interface_fix)}
+  - path: /provision/license.py
+    owner: root:root
+    permissions: "0700"
+    content: |
+      ${indent(6, license)}
   - path: /etc/virl2-base-config.yml
     owner: root:root
     permissions: "0644"

--- a/modules/deploy/data/cml.sh
+++ b/modules/deploy/data/cml.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
-
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
-
 # :%!shfmt -ci -i 4 -
 # set -x
 # set -e

--- a/modules/deploy/data/cml.sh
+++ b/modules/deploy/data/cml.sh
@@ -33,13 +33,13 @@ function setup_pre_azure() {
 function wait_for_network_manager() {
     counter=0
     max_wait=60
-    
+
     while ! systemctl is-active --quiet NetworkManager && [ $counter -lt $max_wait ]; do
         echo "Waiting for NetworkManager to become active..."
         sleep 5
         counter=$((counter + 5))
     done
-    
+
     if systemctl is-active --quiet NetworkManager; then
         echo "NetworkManager is active."
     else

--- a/modules/deploy/data/common.sh
+++ b/modules/deploy/data/common.sh
@@ -1,3 +1,8 @@
+#
+# This file is part of Cisco Modeling Labs
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
+# All rights reserved.
+#
 CONFIG_FILE="/etc/virl2-base-config.yml"
 
 function is_controller() {

--- a/modules/deploy/data/copyfile.sh
+++ b/modules/deploy/data/copyfile.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/data/del.sh
+++ b/modules/deploy/data/del.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 #

--- a/modules/deploy/data/interface_fix.py
+++ b/modules/deploy/data/interface_fix.py
@@ -30,20 +30,23 @@ def get_interface_names(netplan_file):
     return [interface[0] for interface in interfaces]  # Return just the interface names
 
 
-def update_netplan_config(netplan_file, renderer="NetworkManager"):
+def update_netplan_config(netplan_file, primary_interface, renderer="NetworkManager"):
     """Updates the Netplan config file with the specified renderer.
 
     Args:
         netplan_file (str): Path to the Netplan configuration file.
+        primary_interface (str): The primary network interface to update.
         renderer (str, optional): The renderer to use. Defaults to 'NetworkManager'.
     """
     with open(netplan_file, "r") as f:
         netplan_data = yaml.safe_load(f)
 
-    if "network" not in netplan_data:
-        netplan_data["network"] = {}
-
+    netplan_data.setdefault("network", {})
     netplan_data["network"]["renderer"] = renderer
+
+    ethernets = netplan_data["network"].get("ethernets", {})
+    if primary_interface in ethernets:
+        ethernets[primary_interface]["renderer"] = renderer
 
     with open(netplan_file, "w") as f:
         yaml.safe_dump(netplan_data, f)
@@ -76,13 +79,13 @@ def main():
 
     # Get interface names
     interface_names = get_interface_names(netplan_file)
-
-    # Update Netplan config
-    update_netplan_config(netplan_file)
-
-    # Update VIRL2 config
     primary_interface = interface_names[0]
     cluster_interface = interface_names[1] if len(interface_names) > 1 else None
+
+    # Update Netplan config
+    update_netplan_config(netplan_file, primary_interface)
+
+    # Update VIRL2 config
     update_virl2_config(virl2_config_file, primary_interface, cluster_interface)
 
 

--- a/modules/deploy/data/interface_fix.py
+++ b/modules/deploy/data/interface_fix.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+#
+# This file is part of Cisco Modeling Labs
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
+# All rights reserved.
+#
+
 import yaml
 
 

--- a/modules/deploy/data/license.py
+++ b/modules/deploy/data/license.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+#
+# This file is part of Cisco Modeling Labs
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
+# All rights reserved.
+#
+
+import os
+import virl2_client as pcl
+from time import sleep
+
+# VIRL_USERNAME and VIRL_PASSWORD from the environment
+nodes = os.getenv("CFG_LICENSE_NODES") or 0
+token = os.getenv("CFG_LICENSE_TOKEN")
+flavor = os.getenv("CFG_LICENSE_FLAVOR")
+admin_user = os.getenv("CFG_APP_USER")
+admin_pass = os.getenv("CFG_APP_PASS")
+
+regid = (
+    "regid.2019-10.com.cisco.CML_NODE_COUNT,1.0_2607650b-6ca8-46d5-81e5-e6688b7383c4"
+)
+client = pcl.ClientLibrary(
+    "localhost", username=admin_user, password=admin_pass, ssl_verify=False
+)
+
+# this can fail as -dev0 builds already have the flavor set to enterprise!
+try:
+    client.licensing.set_product_license(flavor)
+except pcl.exceptions.APIError as exc:
+    print("uh-oh", exc)
+
+try:
+    client.licensing.register(token)
+    if flavor == "CML_Enterprise":
+        client.licensing.update_features({regid: int(nodes)})
+except pcl.exceptions.APIError as exc:
+    print("uh-oh", exc)
+
+authorized = False
+attempts = 24
+while not authorized and attempts > 0:
+    status = client.licensing.status()
+    authorized = status["authorization"]["status"] == "IN_COMPLIANCE"
+    attempts -= 1
+    sleep(5)
+
+if attempts == 0 and not authorized:
+    print("system did not get into compliant state")

--- a/modules/deploy/data/vars.sh
+++ b/modules/deploy/data/vars.sh
@@ -1,3 +1,8 @@
+#
+# This file is part of Cisco Modeling Labs
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
+# All rights reserved.
+#
 CFG_APP_SOFTWARE="${cfg.app.software}"
 CFG_APP_PASS="${cfg.secrets.app.secret}"
 CFG_APP_USER="${cfg.secrets.app.username}"

--- a/modules/deploy/dummy/main.tf
+++ b/modules/deploy/dummy/main.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/main.tf
+++ b/modules/deploy/main.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/main.tf
+++ b/modules/deploy/main.tf
@@ -16,6 +16,7 @@ locals {
     copyfile      = file("${path.module}/data/copyfile.sh")
     del           = file("${path.module}/data/del.sh")
     interface_fix = file("${path.module}/data/interface_fix.py")
+    license       = file("${path.module}/data/license.py")
     extras        = var.extras
     rand_id       = random_id.id.hex
   }

--- a/modules/deploy/output.tf
+++ b/modules/deploy/output.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/deploy/variables.tf
+++ b/modules/deploy/variables.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/readyness/main.tf
+++ b/modules/readyness/main.tf
@@ -1,11 +1,11 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 
 data "cml2_system" "state" {
-  timeout       = "10m"
+  timeout       = "20m"
   ignore_errors = true
 }
 

--- a/modules/readyness/output.tf
+++ b/modules/readyness/output.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/readyness/terraform.tf
+++ b/modules/readyness/terraform.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/conjur-off.t-f
+++ b/modules/secrets/conjur-off.t-f
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/conjur-on.t-f
+++ b/modules/secrets/conjur-on.t-f
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/conjur/main.tf
+++ b/modules/secrets/conjur/main.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/conjur/output.tf
+++ b/modules/secrets/conjur/output.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/conjur/terraform.tf
+++ b/modules/secrets/conjur/terraform.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/conjur/variables.tf
+++ b/modules/secrets/conjur/variables.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/dummy/main.tf
+++ b/modules/secrets/dummy/main.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/dummy/output.tf
+++ b/modules/secrets/dummy/output.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/dummy/terraform.tf
+++ b/modules/secrets/dummy/terraform.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/dummy/variables.tf
+++ b/modules/secrets/dummy/variables.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/output.tf
+++ b/modules/secrets/output.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/variables.tf
+++ b/modules/secrets/variables.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/vault-off.t-f
+++ b/modules/secrets/vault-off.t-f
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/vault-on.t-f
+++ b/modules/secrets/vault-on.t-f
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/vault/main.tf
+++ b/modules/secrets/vault/main.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/vault/output.tf
+++ b/modules/secrets/vault/output.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/vault/terraform.tf
+++ b/modules/secrets/vault/terraform.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/modules/secrets/vault/variables.tf
+++ b/modules/secrets/vault/variables.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/output.tf
+++ b/output.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/prepare.bat
+++ b/prepare.bat
@@ -1,7 +1,7 @@
 @echo off
 rem
 rem This file is part of Cisco Modeling Labs
-rem Copyright (c) 2019-2024, Cisco Systems, Inc.
+rem Copyright (c) 2019-2025, Cisco Systems, Inc.
 rem All rights reserved.
 rem
 

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 

--- a/upload-images-to-aws.sh
+++ b/upload-images-to-aws.sh
@@ -60,7 +60,7 @@ if [ -z "$(which dialog)" ]; then
     exit 255
 fi
 
-if [ ! -d $ISO ]; then 
+if [ ! -d $ISO ]; then
     echo "Provided reference platform path \"$ISO\" does not exist!"
     exit 255
 fi
@@ -91,7 +91,7 @@ if [ -n "$cmlpkg" ]; then
 fi
 
 pushd &>/dev/null virl-base-images
-options=$(find . -name '*.yaml' -exec sh -c 'basename '{}'; echo "on"' \; )
+options=$(find . -name '*.yaml' -exec sh -c 'basename '{}'; echo "on"' \;)
 popd &>/dev/null
 
 if [ -z "$options" ]; then
@@ -100,8 +100,9 @@ if [ -z "$options" ]; then
     exit 255
 fi
 
-selection=$(dialog --stdout --no-items --separate-output --checklist \
-    "Select images to copy to AWS bucket \"${BUCKETNAME}\"" 0 60 20 $options \
+selection=$(
+    dialog --stdout --no-items --separate-output --checklist \
+        "Select images to copy to AWS bucket \"${BUCKETNAME}\"" 0 60 20 $options
 )
 s=$?
 clear

--- a/upload-images-to-aws.sh
+++ b/upload-images-to-aws.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 # This script can be installed on an on-prem CML controller which also has the

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 #
 # This file is part of Cisco Modeling Labs
-# Copyright (c) 2019-2024, Cisco Systems, Inc.
+# Copyright (c) 2019-2025, Cisco Systems, Inc.
 # All rights reserved.
 #
 
@@ -34,13 +34,13 @@ variable "aws_secret_key" {
 
 # Azure related vars
 
-variable "subscription_id" {
+variable "azure_subscription_id" {
   type        = string
   description = "Azure subscription ID"
   default     = "notset"
 }
 
-variable "tenant_id" {
+variable "azure_tenant_id" {
   type        = string
   description = "Azure tenant ID"
   default     = "notset"


### PR DESCRIPTION
## Fixes for CML 2.8 and more

- overall, should fix #27 to allow deployments on AWS and Azure with 2.8
- changed variable names for AWS access and secret keys to start with
  aws_ (e.g. TF_VAR_access_key -> TF_VAR_aws_access_key), same for Azure
  subscription_id and tenant_id.
- do product licensing using the PCL instead of the cml.sh script (fixes
  #28)
- fix letsencrypt certificate installation for nginx and Cockpit
- add i386 repository to allow installation of older libraries for IOL
  compatibility
- whitespace and formatting of files
- for Azure, use the "minimal" SKU of the Noble image (instead of
  "server")
- slightly more comprehensive log output in cml.sh to see where time is
  spent when deploying
- update copyright to include 2025
- update the VMX patch script
- better NetworkManager interaction (wait_for_network_manager)